### PR TITLE
disable the status service differently

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 DEFAULT_EXCHANGE_HOST=http://localhost:4004
 REDIS_URI=redis://127.0.0.1:6379
 KEYV_WRITE_DELAY=50
-STATUS_SERVICE="" # Disables status
+STATUS_SERVICE="http://localhost:4006" # default, remove to disable

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,6 @@ let CONFIG: App.Config
 
 const defaultPort = 4004
 const defaultExchangeHost = 'http://localhost:4004'
-const defaultStatusService = 'http://localhost:4008'
 const defaultSigningService = 'http://localhost:4006'
 const defaultWorkflow = 'didAuth'
 const defaultTenantName = 'default'
@@ -33,11 +32,7 @@ const parseConfig = (): App.Config => {
     port: parseInt(process.env.PORT ?? '0') || defaultPort,
     defaultExchangeHost: process.env.EXCHANGE_HOST ?? defaultExchangeHost,
     exchangeTtl: parseInt(process.env.EXCHANGE_TTL ?? '0') || defaultTtlSeconds,
-    // status service is optional, set STATUS_SERVICE="" (empty string) to disable.
-    statusService:
-      process.env.STATUS_SERVICE !== undefined
-        ? process.env.STATUS_SERVICE
-        : defaultStatusService,
+    statusService: process.env.STATUS_SERVICE ?? '',
     signingService: process.env.SIGNING_SERVICE ?? defaultSigningService,
 
     defaultWorkflow: process.env.DEFAULT_WORKFLOW ?? defaultWorkflow,

--- a/src/transactionManager.ts
+++ b/src/transactionManager.ts
@@ -1,9 +1,9 @@
 /*!
  * Copyright (c) 2023 Digital Credentials Consortium. All rights reserved.
  */
+import KeyvRedis from '@keyv/redis'
 import { HTTPException } from 'hono/http-exception'
 import Keyv from 'keyv'
-import KeyvRedis from '@keyv/redis'
 import { KeyvFile } from 'keyv-file'
 import { getConfig } from './config.js'
 


### PR DESCRIPTION
I noticed in AWS when we set STATUS_SERVICE="" it appears it comes in as `undefined` which caused this to fallback to the default. This way if it is not supplied it falls back to "" which disables it.