### PR TITLE
Improve VC-API conformance by unpacking VP

### DIFF
--- a/src/verifiablePresentation.ts
+++ b/src/verifiablePresentation.ts
@@ -6,7 +6,10 @@ import { arrayOf } from './utils.js'
  * @returns
  */
 export const preparePresentation = (presentation: Record<string, unknown>) => {
-  const _presentation = { ...presentation }
+  const _presentation =
+    !presentation?.['@context'] && presentation.verifiablePresentation
+      ? { ...presentation.verifiablePresentation }
+      : { ...presentation }
   const proof = presentation?.proof as {
     type: string | string[]
     '@context': string | string[] | undefined


### PR DESCRIPTION
from verifiablePresentation property

Conformant products will post a {verifiablePresentation} participation response, not just post the VP as the request body. Handle both ways.