### PR TITLE
fix(docker): use pnpm instead of npm in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:22-alpine
 WORKDIR /app
 COPY . .
-RUN npm install
-RUN npm run build
+RUN corepack enable && corepack prepare --activate
+RUN pnpm install
+RUN pnpm build
 CMD ["node", "dist/server.js"]
 EXPOSE 4004

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "engines": {
     "node": ">=22.0"
   },
+  "packageManager": "pnpm@10.13.1",
   "author": {
     "name": "Digital Credentials Consortium",
     "url": "https://github.com/digitalcredentials/"


### PR DESCRIPTION
Add packageManager field to package.json to enable corepack, and update Dockerfile to use pnpm for dependency management. This fixes the Docker build failure caused by npm/pnpm mismatch.