### PR TITLE
chore(docker): add git binary to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:22-alpine
 WORKDIR /app
+RUN apk add --no-cache git
 COPY . .
 RUN corepack enable && corepack prepare --activate
 RUN pnpm install


### PR DESCRIPTION
Docker needs to be able to use git to check out temporary verifier-core dependency via git