### PR TITLE
fix(build): Add build ui to default build for docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.3.1",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && pnpm build:ui",
     "start": "node -r dotenv/config dist/server.js",
     "dev": "pnpm build:ui && nodemon -r dotenv/config --exec tsx src/server.ts",
     "dev-noenv": "nodemon --exec tsx src/server.ts",


### PR DESCRIPTION
The build script now runs both TypeScript compilation and the UI build:


package.json
Lines 7-7
"build": "tsc && pnpm build:ui",
This ensures that when pnpm build runs during the Docker build, it will:

Compile TypeScript to dist/
Build the Vite React UI into dist/ui/
The resulting dist/ui/index.html will then be available at runtime in the container.